### PR TITLE
Make more easily compatible with Node.js

### DIFF
--- a/code/go-wasm/index.html
+++ b/code/go-wasm/index.html
@@ -15,9 +15,12 @@
       const reader = new FileReader();
       reader.onload = function(event) {
         var buffer = new Uint8Array(reader.result);
-        validateZipBuffer(input.files[0], buffer,
-	  () => { result.innerHTML = "Package is valid" },
-	  (errors) => { result.innerHTML = errors.replaceAll("\n", "<br />") })
+        validateZipBuffer(
+          input.files[0].name,
+          input.files[0].size,
+          buffer,
+          () => { result.innerHTML = "Package is valid" },
+          (errors) => { result.innerHTML = errors.replaceAll("\n", "<br />") })
       };
       reader.readAsArrayBuffer(input.files[0]);
     })

--- a/code/go-wasm/main.go
+++ b/code/go-wasm/main.go
@@ -63,19 +63,21 @@ func main() {
 
 	module.Set("validateFromZipReader", asyncFunc(
 		func(this js.Value, args []js.Value) interface{} {
-			if len(args) < 1 || !args[0].InstanceOf(js.Global().Get("File")) {
-				return fmt.Errorf("file object expected")
+			if len(args) < 1 || args[0].Type() != js.TypeString {
+				return fmt.Errorf("string expected")
 			}
-			if len(args) < 2 || !args[1].InstanceOf(js.Global().Get("Uint8Array")) {
+			if len(args) < 2 || args[1].Type() != js.TypeNumber {
+				return fmt.Errorf("number expected")
+			}
+			if len(args) < 3 || !args[2].InstanceOf(js.Global().Get("Uint8Array")) {
 				return fmt.Errorf("array buffer with content of package expected")
 			}
 
-			file := args[0]
-			name := file.Get("name").String()
-			size := int64(file.Get("size").Int())
+			name := args[0].String()
+			size := int64(args[1].Int())
 
 			buf := make([]byte, size)
-			js.CopyBytesToGo(buf, args[1])
+			js.CopyBytesToGo(buf, args[2])
 
 			reader := bytes.NewReader(buf)
 			return validator.ValidateFromZipReader(name, reader, size)

--- a/code/go-wasm/validate.lib.js
+++ b/code/go-wasm/validate.lib.js
@@ -6,11 +6,11 @@ fetch('validator.wasm').then((response) => {
 })
 const go = new Go();
 
-function validateZipBuffer(file, buffer, success, error) {
+function validateZipBuffer(name, size, buffer, success, error) {
 	WebAssembly.instantiate(wasmBuffer, go.importObject).then((validator) => {
 		go.run(validator.instance);
 
-		elasticPackageSpec.validateFromZipReader(file, buffer).then(() => 
+		elasticPackageSpec.validateFromZipReader(name, size, buffer).then(() => 
 			success()
 		).catch((err) => 
 			error(err)


### PR DESCRIPTION
Since Node.js doesn't have the global File class, I made this more portable by using separate parameters for the `name` and `size` properties that were being used.

I've got this working against this PR in Kibana https://github.com/elastic/kibana/pull/128076